### PR TITLE
provide unambiguous license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <licenses>
         <license>
-            <name>lgpl</name>
+            <name>GNU Lesser General Public License v2.1 or later</name>
             <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
If this ever gets a new version I'd like it to have a proper license name, "lgpl" is ambiguous and under the proposed changes to the license plugin it will still require a manual override.